### PR TITLE
Read context from parameter http Run()

### DIFF
--- a/http.go
+++ b/http.go
@@ -60,8 +60,8 @@ func NewServerMux(opts ServeOpts) *Server {
 	}, Port: opts.Port}
 }
 
-func (s *Server) Run(handler http.Handler) error {
-	ctx, cancel := context.WithCancel(context.Background())
+func (s *Server) Run(handler http.Handler, ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	s.httpServer.Handler = handler
 	// Description µ micro service

--- a/http.go
+++ b/http.go
@@ -61,8 +61,6 @@ func NewServerMux(opts ServeOpts) *Server {
 }
 
 func (s *Server) Run(handler http.Handler, ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	s.httpServer.Handler = handler
 	// Description µ micro service
 	fmt.Println(


### PR DESCRIPTION
I suggest to put context inside those parameter

we could use context from opentracing's return
https://github.com/opentracing/opentracing-go/blob/3088eee7e4d26010ac9a301e977fd2721dbebcbe/gocontext.go#L48

and pass it into Run() that can be handle in quite func

Or even we didn't use opentracing, we could define context in App func